### PR TITLE
BUGFIX: Handle nested XML tags

### DIFF
--- a/lib/xmlsplit.js
+++ b/lib/xmlsplit.js
@@ -79,15 +79,18 @@ XmlSplit.prototype._transform = function(chunk, encoding, done) {
       if (dataChunks.length > 1) {
         var lastChunkIndex = dataChunks.length-1
         var dataChunk = ""
+        var closeTagCount = 0
         dataChunks.forEach(function(data, index) {
           dataChunk += data
+          closeTagCount++
           if (index === lastChunkIndex) {
             this._data = dataChunk
           } else {
 
-            // count the open tags inside the chunk
-            var openTagCount = countOpenTags(this._tagName, data)
-            if (openTagCount === 2) {
+            // Count the open tags inside the chunk and check if they do match with the closing ones
+            if (countOpenTags(this._tag, dataChunk) !== closeTagCount) {
+              // If not append the closing tag to the dataChunk and iterate
+              // (we have at lease one this._tag in the inner XML fragment)
               dataChunk += token
               return
             }
@@ -101,6 +104,7 @@ XmlSplit.prototype._transform = function(chunk, encoding, done) {
             this._index++
           }
           dataChunk = ""
+          closeTagCount = 0
         }, this)
       }
       while (this._batchSize && this._buffer.length >= this._batchSize) {

--- a/lib/xmlsplit.js
+++ b/lib/xmlsplit.js
@@ -29,6 +29,13 @@ XmlSplit.prototype._flush = function(done) {
 
 XmlSplit.prototype._transform = function(chunk, encoding, done) {
 
+  function countOpenTags(tagName, text) {
+    var count = 0
+    var re = new RegExp('<\\s*'+tagName+'\\s+','mgi')
+    while (re.exec(text)) count++
+    return count
+  }
+
   this._data += chunk.toString()
 
   // remove all xml comments from input (which could be multi-lined)
@@ -71,10 +78,20 @@ XmlSplit.prototype._transform = function(chunk, encoding, done) {
       var dataChunks = this._data.split(token)
       if (dataChunks.length > 1) {
         var lastChunkIndex = dataChunks.length-1
-        dataChunks.forEach(function(dataChunk, index) {
+        var dataChunk = ""
+        dataChunks.forEach(function(data, index) {
+          dataChunk += data
           if (index === lastChunkIndex) {
             this._data = dataChunk
           } else {
+
+            // count the open tags inside the chunk
+            var openTagCount = countOpenTags(this._tagName, data)
+            if (openTagCount === 2) {
+              dataChunk += token
+              return
+            }
+
             if (this._batchSize) {
               this._buffer.push(dataChunk + token)
             } else {
@@ -83,6 +100,7 @@ XmlSplit.prototype._transform = function(chunk, encoding, done) {
             }
             this._index++
           }
+          dataChunk = ""
         }, this)
       }
       while (this._batchSize && this._buffer.length >= this._batchSize) {

--- a/tests/fixtures/xml-sample-with-inner-tag.xml
+++ b/tests/fixtures/xml-sample-with-inner-tag.xml
@@ -1,0 +1,14 @@
+<order>
+	<book ISBN="10-861003-324">
+		<title>The Handmaid's Tale</title>
+		<price>19.95</price>
+		<book ISBN="10-861003-324">
+			<title>The Handmaid's Tale</title>
+			<price>19.95</price>
+		</book>
+	</book>
+	<book ISBN="10-861003-324">
+		<title>The Handmaid's Tale</title>
+		<price>19.95</price>
+	</book>
+</order>

--- a/tests/fixtures/xml-sample-with-inner-tag.xml
+++ b/tests/fixtures/xml-sample-with-inner-tag.xml
@@ -6,6 +6,14 @@
 			<title>The Handmaid's Tale</title>
 			<price>19.95</price>
 		</book>
+		<book ISBN="10-861003-324">
+			<title>The Handmaid's Tale</title>
+			<price>19.95</price>
+			<book ISBN="10-861003-324">
+				<title>The Handmaid's Tale</title>
+				<price>19.95</price>
+			</book>
+		</book>
 	</book>
 	<book ISBN="10-861003-324">
 		<title>The Handmaid's Tale</title>

--- a/tests/test-xmlsplit.js
+++ b/tests/test-xmlsplit.js
@@ -214,4 +214,48 @@ describe('XmlSplit', function() {
 
   })
 
+  describe('XML input file with split tag in the inner XML block', function() {
+
+    var xmlSplit
+      , fixtureFilename = 'fixtures/xml-sample-with-inner-tag.xml'
+
+    before(function() {
+      xmlSplit = new XmlSplit(1, 'book')
+    })
+
+    it('should parse file', function(done) {
+      var stream = fs.createReadStream(path.resolve(__dirname, fixtureFilename))
+      stream.pipe(xmlSplit)
+
+      var count = 0
+      xmlSplit.on('data', function(data) {
+        count++
+      }).on('end', function() {
+        count.should.be.eql(2)
+        done()
+      })
+    })
+
+    it('should parse file line by line', function(done) {
+      var xmlSplit = new XmlSplit(1, 'book')
+
+      fs.readFileSync(path.resolve(__dirname, fixtureFilename), 'utf8')
+      .split(/\n/)
+      .forEach(function(line) {
+        xmlSplit.write(line + "\n", 'utf8')
+      })
+      xmlSplit.end()
+
+      var count = 0
+      xmlSplit.on('data', function(data) {
+        count++
+      }).on('end', function() {
+        count.should.be.eql(2)
+        done()
+      })
+    })
+
+
+  })
+
 })


### PR DESCRIPTION
While splitting for a specific tag and having the same tag nested inside
the inner XML fragment, the engine produces invalid XML documents.

This commit should fix this issue, see the included test cases.

Fixes #4 
