### PR TITLE
Changing regex to allow nodes with prefixes

### DIFF
--- a/lib/xmlsplit.js
+++ b/lib/xmlsplit.js
@@ -46,7 +46,7 @@ XmlSplit.prototype._transform = function(chunk, encoding, done) {
 
   if (!this._header) {
     // check if we have the full xml header in the input data
-    var res = (/<(\w+)[>\s]/mg).exec(this._data)
+    var res = (/<([\w:]+)[>\s]/mg).exec(this._data)
     if (res !== null) {
       var tagName = res[1]
       this._headerEndTag = '</' + tagName + '>'
@@ -61,7 +61,7 @@ XmlSplit.prototype._transform = function(chunk, encoding, done) {
     if (!this._tag) {
       // if there is a preconfigured tag, try to find that one, else autodetect
       var re = this._tagName ? new RegExp('<('+this._tagName+')','mgi')
-             : /<(\w+)[\s>]/mg
+             : /<([\w:]+)[\s>]/mg
 
       var res = re.exec(this._data)
       if (res !== null) {


### PR DESCRIPTION
For your consideration.
A very small change.
When using the original code it was ignoring nodes with prefixes, such as:
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<prefix:books xmlns:prefix="http://www.somesite.com/XMLSchema/ns/somesystem">
    <prefix:book ISBN="10-861003-324">
        <prefix:title>The Handmaid's Tale</title>
        <prefix:price>19.95</price>
    </prefix:book>
    <prefix:book ISBN="10-861003-324">
        <prefix:title>The Handmaid's Tale</title>
        <prefix:price>19.95</price>
    </prefix:book>
</prefix:books>
```
Changing the regx from 
```
/<(\w+)[>\s]/mg
```
to
```
/<([\w:]+)[>\s]/mg
``` 
now works for nodes with or without prefixes 