### PR TITLE
Tests should include self-closing tags

### DIFF
--- a/tests/fixtures/items.xml
+++ b/tests/fixtures/items.xml
@@ -16,9 +16,9 @@
 			</xml>
 		</some>
 	</item>
-	<item id=2>only text value</item>
-	<item id=3>only text value</item>
-	<item id=4>only text value</item>
+	<item id=2></item>
+	<item id=3/>
+	<item id=4 />
 	<item id=5>only text value</item>
 	<item id=6>only text value</item>
 	<item id=7>only text value</item>


### PR DESCRIPTION
Xmlsplit appears not to handle self-closing tags: it appears to think it has seen only the open-tag and never finds the balanced close-tag. This PR demonstrates the problem, causing the test suite to fail, but I have not written a fix.